### PR TITLE
feat : 곡 업로드 버튼 및 모달 추가

### DIFF
--- a/src/apis/Track/useUploadTrack.ts
+++ b/src/apis/Track/useUploadTrack.ts
@@ -1,0 +1,15 @@
+import axios from '@/apis/axios';
+import { UploadTrackResponse } from '@/typings/Track/track';
+import { TCommonResponse } from '@/typings/Service/API';
+import { API_ENDPOINTS } from '@/constants/Endpoints';
+
+export const uploadTrackApi = (file: File) => {
+  const formData = new FormData();
+  formData.append('file', file);
+
+  return axios.post<TCommonResponse<UploadTrackResponse>>(API_ENDPOINTS.COMPOSER.UPLOAD_TRACK, formData, {
+    headers: {
+      'Content-Type': 'multipart/form-data',
+    },
+  });
+};

--- a/src/constants/Endpoints.ts
+++ b/src/constants/Endpoints.ts
@@ -13,6 +13,7 @@ export const API_ENDPOINTS = {
     COMPANY_EXISTS: `${BASE_URL}/user/company-exists`,
   },
   COMPOSER: {
-    GET_TRACKS: `${BASE_URL}/composer/track`
+    GET_TRACKS: `${BASE_URL}/composer/track`,
+    UPLOAD_TRACK: `${BASE_URL}/composer/track/upload`
   }
 };

--- a/src/constants/TrackFile.ts
+++ b/src/constants/TrackFile.ts
@@ -1,0 +1,4 @@
+export const TRACK_FILE = {
+    MAX_FILE_SIZE: 100 * 1024 * 1024, // 100MB in bytes
+    ALLOWED_EXTENSIONS: ['mp3', 'wav'],
+  };

--- a/src/pages/Composer/Track/TrackList/Components/TrackUploadModal.tsx
+++ b/src/pages/Composer/Track/TrackList/Components/TrackUploadModal.tsx
@@ -1,0 +1,92 @@
+import React, { useState } from 'react';
+import { uploadTrackApi } from '@/apis/Track/useUploadTrack';
+import { TRACK_FILE } from '@/constants/TrackFile';
+
+interface TrackUploadModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onUploadSuccess: () => void;
+}
+
+const TrackUploadModal: React.FC<TrackUploadModalProps> = ({ isOpen, onClose, onUploadSuccess }) => {
+  const [file, setFile] = useState<File | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isUploading, setIsUploading] = useState(false);
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const selectedFile = e.target.files?.[0];
+    if (selectedFile) {
+      if (selectedFile.size > TRACK_FILE.MAX_FILE_SIZE) {
+        setError('파일 크기는 100MB를 초과할 수 없습니다.');
+        return;
+      }
+      const fileExtension = selectedFile.name.split('.').pop()?.toLowerCase();
+      if (!fileExtension || !TRACK_FILE.ALLOWED_EXTENSIONS.includes(fileExtension)) {
+        setError('허용되는 파일 형식은 .mp3와 .wav입니다.');
+        return;
+      }
+      setFile(selectedFile);
+      setError(null); // 파일이 유효할 때 에러 초기화
+    }
+  };
+
+  const handleUpload = async () => {
+    if (!file) {
+      setError('파일을 선택해주세요.');
+      return;
+    }
+    setIsUploading(true);
+    setError(null);
+    try {
+      const response = await uploadTrackApi(file);
+      if (response.data.code === 'SUCCESS_NORMAL') {
+        onUploadSuccess();
+        onClose();
+      } else {
+        setError('업로드에 실패했습니다. 다시 시도해주세요.');
+      }
+    } catch (error) {
+      setError('업로드 중 오류가 발생했습니다.');
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
+      <div className="bg-white p-6 rounded-lg">
+        <h2 className="text-xl font-bold mb-4">곡 업로드</h2>
+        <div className="mb-4">
+          <input 
+            type="file" 
+            onChange={handleFileChange} 
+            accept=".mp3,.wav" 
+            disabled={isUploading}
+          />
+        </div>
+        {error && <p className="text-red-500 mb-4">{error}</p>}
+        {isUploading && <p className="text-blue-500 mb-4">업로드 중입니다. 잠시만 기다려주세요...</p>}
+        <div className="flex justify-end">
+          <button 
+            onClick={onClose} 
+            className="mr-2 px-4 py-2 bg-gray-200 rounded"
+            disabled={isUploading}
+          >
+            취소
+          </button>
+          <button 
+            onClick={handleUpload} 
+            className={`px-4 py-2 ${isUploading || error ? 'bg-gray-400' : 'bg-black'} text-white rounded`}
+            disabled={isUploading || !file || error !== null}
+          >
+            {isUploading ? '업로드 중...' : '업로드'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TrackUploadModal;

--- a/src/pages/Composer/Track/TrackList/index.tsx
+++ b/src/pages/Composer/Track/TrackList/index.tsx
@@ -1,21 +1,35 @@
 import React, { useEffect, useState } from 'react';
 import { observer } from 'mobx-react-lite';
 import { trackStore } from '@/stores/Track/TracksStore';
+import TrackUploadModal from './Components/TrackUploadModal';
 
 const TrackListPage: React.FC = observer(() => {
-  const [page, setPage] = useState(1); // 첫 요청은 1페이지부터 시작
+  const [page, setPage] = useState(1);
+  const [isUploadModalOpen, setIsUploadModalOpen] = useState(false);
 
   useEffect(() => {
-    trackStore.fetchTracks(page); // 페이지 변경 시 API 호출
+    trackStore.fetchTracks(page);
   }, [page]);
 
   const handlePageChange = (newPage: number) => {
     setPage(newPage);
   };
 
+  const handleUploadSuccess = () => {
+    trackStore.fetchTracks(page);
+  };
+
   return (
     <div>
-      <h1 className="text-2xl font-bold mb-4">곡 업로드 목록</h1>
+      <div className="flex justify-between items-center mb-4">
+        <h1 className="text-2xl font-bold">곡 업로드 목록</h1>
+        <button 
+          onClick={() => setIsUploadModalOpen(true)}
+          className="px-4 py-2 bg-black text-white rounded"
+        >
+          곡 업로드
+        </button>
+      </div>
       <div className="bg-white shadow overflow-hidden sm:rounded-lg">
         <table className="min-w-full divide-y divide-gray-200">
           <thead className="bg-gray-50">
@@ -48,6 +62,12 @@ const TrackListPage: React.FC = observer(() => {
           </button>
         ))}
       </div>
+
+      <TrackUploadModal 
+        isOpen={isUploadModalOpen}
+        onClose={() => setIsUploadModalOpen(false)}
+        onUploadSuccess={handleUploadSuccess}
+      />
     </div>
   );
 });

--- a/src/typings/Track/track.ts
+++ b/src/typings/Track/track.ts
@@ -3,3 +3,8 @@ export interface TrackItem {
     title: string;
     artist: string;
   }
+
+export interface UploadTrackResponse {
+    id: number;
+    fileName: string;
+}


### PR DESCRIPTION
### 작업 설명
- 곡 업로드 버튼 및 모달 추가
- 업로드 용량은 100MB로 제한
- 업로드 확장자는 .mp3, .wav만 허용

--- 

### 고려할 점
